### PR TITLE
Change url to AWS API gateway, trigger to lambda function

### DIFF
--- a/companion/index.js
+++ b/companion/index.js
@@ -95,7 +95,8 @@ messaging.peerSocket.addEventListener("message", (evt) => {
   
   if (evt.data) {
   // get location 
-      let url = `https://budslab.me`
+      // AWS API gateway link, triggers lambda function
+      let url = `https://ay1bwnlt74.execute-api.us-east-1.amazonaws.com/test`
 
       
       fetch(url, {


### PR DESCRIPTION
Changed (https://budslab.me) url to AWS API gateway that triggers lambda function. Lambda function make responses directly to both influxDB and Digital Ocean.